### PR TITLE
Preserve and prefer Torrentio magnet URLs in TorrentPlayer

### DIFF
--- a/src/components/player/TorrentPlayer.tsx
+++ b/src/components/player/TorrentPlayer.tsx
@@ -1,6 +1,7 @@
 import { Box, LinearProgress, Typography } from "@mui/joy";
 import { useEffect, useMemo, useRef, useState } from "react";
 import WebTorrent, { type WebTorrentFile } from "webtorrent/dist/webtorrent.min.js";
+import type { TorrentioStreamMetadata } from "../../hooks/useTorrentio";
 
 const WEBRTC_TRACKERS = [
   "wss://tracker.btorrent.xyz",
@@ -9,7 +10,9 @@ const WEBRTC_TRACKERS = [
 ];
 
 type TorrentPlayerProps = {
-  infoHash: string;
+  stream?: TorrentioStreamMetadata | null;
+  torrentIdentifier?: string;
+  infoHash?: string;
 };
 
 type TorrentStatus = "idle" | "connecting" | "downloading" | "ready" | "error";
@@ -26,25 +29,72 @@ const bytesPerSecondLabel = (bytesPerSecond: number) => {
   return `${Math.round(bytesPerSecond)} B/s`;
 };
 
+const normalizeInfoHash = (value: string) => value.trim().replace(/^urn:btih:/i, "").replace(/^btih:/i, "");
+
+const BARE_INFO_HASH_PATTERN = /^(?:urn:btih:|btih:)?[a-z0-9]{32,40}$/i;
+
+const isMagnetUri = (value: string) => value.trim().toLowerCase().startsWith("magnet:?");
+
+const isBareInfoHash = (value: string) => BARE_INFO_HASH_PATTERN.test(value.trim());
+
+const ensureWebRtcTrackers = (magnetUri: string) => {
+  const normalizedMagnetUri = magnetUri.trim();
+  const queryStartIndex = normalizedMagnetUri.indexOf("?");
+
+  if (queryStartIndex < 0) {
+    return normalizedMagnetUri;
+  }
+
+  const prefix = normalizedMagnetUri.slice(0, queryStartIndex);
+  const query = normalizedMagnetUri.slice(queryStartIndex + 1);
+  const params = new URLSearchParams(query);
+  const existingTrackers = new Set(params.getAll("tr").map((tracker) => tracker.trim().toLowerCase()));
+
+  WEBRTC_TRACKERS.forEach((tracker) => {
+    if (!existingTrackers.has(tracker.toLowerCase())) {
+      params.append("tr", tracker);
+    }
+  });
+
+  return `${prefix}?${params.toString()}`;
+};
+
 const createMagnetUri = (infoHash: string) => {
-  const normalizedInfoHash = infoHash.trim();
+  const normalizedInfoHash = normalizeInfoHash(infoHash);
   const trackers = WEBRTC_TRACKERS.map((tracker) => `tr=${encodeURIComponent(tracker)}`).join("&");
 
   return `magnet:?xt=urn:btih:${encodeURIComponent(normalizedInfoHash)}&${trackers}`;
 };
 
-function TorrentPlayer({ infoHash }: TorrentPlayerProps) {
+const resolveTorrentIdentifier = ({ stream, torrentIdentifier, infoHash }: TorrentPlayerProps) => {
+  const preferredIdentifier = String(stream?.url || torrentIdentifier || stream?.infoHash || infoHash || "").trim();
+
+  if (!preferredIdentifier) {
+    return "";
+  }
+
+  if (isMagnetUri(preferredIdentifier)) {
+    return ensureWebRtcTrackers(preferredIdentifier);
+  }
+
+  return isBareInfoHash(preferredIdentifier) ? createMagnetUri(preferredIdentifier) : preferredIdentifier;
+};
+
+function TorrentPlayer({ stream = null, torrentIdentifier = "", infoHash = "" }: TorrentPlayerProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [status, setStatus] = useState<TorrentStatus>("idle");
   const [progress, setProgress] = useState(0);
   const [downloadSpeed, setDownloadSpeed] = useState(0);
   const [error, setError] = useState("");
 
-  const magnetUri = useMemo(() => (infoHash ? createMagnetUri(infoHash) : ""), [infoHash]);
+  const torrentId = useMemo(
+    () => resolveTorrentIdentifier({ stream, torrentIdentifier, infoHash }),
+    [infoHash, stream, torrentIdentifier],
+  );
 
   useEffect(() => {
     const container = containerRef.current;
-    if (!container || !magnetUri) {
+    if (!container || !torrentId) {
       setStatus("idle");
       return;
     }
@@ -70,7 +120,7 @@ function TorrentPlayer({ infoHash }: TorrentPlayerProps) {
 
     client.on("error", handleClientError);
 
-    const torrent = client.add(magnetUri, (addedTorrent) => {
+    const torrent = client.add(torrentId, (addedTorrent) => {
       const videoFile = addedTorrent.files.find((file: WebTorrentFile) => /\.(mp4|webm)$/i.test(file.name));
 
       if (!videoFile) {
@@ -105,7 +155,7 @@ function TorrentPlayer({ infoHash }: TorrentPlayerProps) {
       container.replaceChildren();
       client.destroy();
     };
-  }, [magnetUri]);
+  }, [torrentId]);
 
   const isLoading = status === "connecting" || status === "downloading";
 

--- a/src/hooks/useTorrentio.ts
+++ b/src/hooks/useTorrentio.ts
@@ -20,6 +20,7 @@ type TorrentioResponse = {
 
 export type TorrentioStreamMetadata = {
   infoHash: string;
+  url?: string;
   seeds: number;
   title: string;
   filename: string;
@@ -90,9 +91,9 @@ export const selectBestTorrentioStream = (
   const candidates = streams
     .filter(isPlayableVideoStream)
     .map((stream) => ({
-      stream,
       infoHash: extractInfoHash(stream),
       seeds: extractSeeds(stream),
+      url: stream.url?.trim() || undefined,
       filename: getStreamFilename(stream),
       title: String(stream.title || stream.name || stream.behaviorHints?.filename || "Torrentio stream"),
     }))
@@ -106,6 +107,7 @@ export const selectBestTorrentioStream = (
 
   return {
     infoHash: best.infoHash,
+    url: best.url,
     seeds: best.seeds,
     title: best.title,
     filename: best.filename,


### PR DESCRIPTION
### Motivation
- Torrentio responses can include a full magnet URL in `url`; the player should prefer and preserve that instead of reducing streams to bare info hashes. 
- Generated magnet URIs should be a fallback for bare info-hashes only, and WebRTC trackers must be present while keeping any trackers already in the original magnet.

### Description
- Extended `TorrentioStreamMetadata` to include an optional `url` field and preserved `stream.url` in `selectBestTorrentioStream` when choosing the best stream (`src/hooks/useTorrentio.ts`).
- Updated `TorrentPlayer` to accept either the richer `stream?: TorrentioStreamMetadata | null`, a `torrentIdentifier?: string`, or the legacy `infoHash?: string` prop (`src/components/player/TorrentPlayer.tsx`).
- Added identifier resolution that prefers the original Torrentio magnet URL, appends missing WebRTC trackers without removing existing `tr` params, treats bare info-hashes as fallback and only then calls `createMagnetUri`, and otherwise passes through non-magnet/full identifiers unchanged (`src/components/player/TorrentPlayer.tsx`).
- Switched WebTorrent usage to add the resolved full torrent identifier (magnet or other accepted form) instead of always building a magnet from `infoHash` (`src/components/player/TorrentPlayer.tsx`).

### Testing
- Ran `npx eslint src/hooks/useTorrentio.ts src/components/player/TorrentPlayer.tsx` and it completed successfully for the modified files.
- Ran `npm run build`, which failed due to pre-existing unrelated TypeScript errors (unused declarations) elsewhere in the codebase and not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19f5f0e2a8832ca7886adadbadb398)