### PR TITLE
Add TorrentPlayer/Torrentio as a selectable watch provider

### DIFF
--- a/src/components/player/TorrentPlayer.tsx
+++ b/src/components/player/TorrentPlayer.tsx
@@ -1,5 +1,5 @@
 import { Box, LinearProgress, Typography } from "@mui/joy";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type MutableRefObject } from "react";
 import WebTorrent, { type WebTorrentFile } from "webtorrent/dist/webtorrent.min.js";
 import type { TorrentioStreamMetadata } from "../../hooks/useTorrentio";
 
@@ -17,6 +17,16 @@ type TorrentPlayerProps = {
   stream?: TorrentioStreamMetadata | null;
   torrentIdentifier?: string;
   infoHash?: string;
+  playerRef?: MutableRefObject<HTMLVideoElement | null>;
+  poster?: string;
+  title?: string;
+  reloadToken?: number;
+  onLoadedMetadata?: () => void;
+  onTimeUpdate?: () => void;
+  onPause?: () => void;
+  onEnded?: () => void;
+  onPlaybackError?: (message: string) => void;
+  onPlaybackReady?: () => void;
 };
 
 type TorrentStatus = "idle" | "connecting" | "downloading" | "ready" | "error";
@@ -36,6 +46,8 @@ const bytesPerSecondLabel = (bytesPerSecond: number) => {
 const normalizeInfoHash = (value: string) => value.trim().replace(/^urn:btih:/i, "").replace(/^btih:/i, "");
 
 const BARE_INFO_HASH_PATTERN = /^(?:urn:btih:|btih:)?[a-z0-9]{32,40}$/i;
+
+const PLAYABLE_VIDEO_PATTERN = /\.(mp4|webm)$/i;
 
 const isMagnetUri = (value: string) => value.trim().toLowerCase().startsWith("magnet:?");
 
@@ -84,7 +96,27 @@ const resolveTorrentIdentifier = ({ stream, torrentIdentifier, infoHash }: Torre
   return isBareInfoHash(preferredIdentifier) ? createMagnetUri(preferredIdentifier) : preferredIdentifier;
 };
 
-function TorrentPlayer({ stream = null, torrentIdentifier = "", infoHash = "" }: TorrentPlayerProps) {
+const selectPlayableVideoFile = (files: WebTorrentFile[]) => {
+  const playableFiles = files.filter((file) => PLAYABLE_VIDEO_PATTERN.test(file.name));
+
+  return playableFiles.sort((a, b) => Number(b.length || 0) - Number(a.length || 0))[0] || null;
+};
+
+function TorrentPlayer({
+  stream = null,
+  torrentIdentifier = "",
+  infoHash = "",
+  playerRef,
+  poster = "",
+  title = "",
+  reloadToken = 0,
+  onLoadedMetadata,
+  onTimeUpdate,
+  onPause,
+  onEnded,
+  onPlaybackError,
+  onPlaybackReady,
+}: TorrentPlayerProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [status, setStatus] = useState<TorrentStatus>("idle");
   const [progress, setProgress] = useState(0);
@@ -100,6 +132,7 @@ function TorrentPlayer({ stream = null, torrentIdentifier = "", infoHash = "" }:
     const container = containerRef.current;
     if (!container || !torrentId) {
       setStatus("idle");
+      if (playerRef) playerRef.current = null;
       return;
     }
 
@@ -107,9 +140,12 @@ function TorrentPlayer({ stream = null, torrentIdentifier = "", infoHash = "" }:
     let hasUsefulTorrentActivity = false;
     let noPeersTimeout: ReturnType<typeof window.setTimeout> | null = null;
     let latestTrackerWarning = "";
+    let activeVideoElement: HTMLVideoElement | null = null;
+    let cleanupVideoListeners = () => {};
     const client = new WebTorrent();
 
     container.replaceChildren();
+    if (playerRef) playerRef.current = null;
     setStatus("connecting");
     setProgress(0);
     setDownloadSpeed(0);
@@ -125,8 +161,10 @@ function TorrentPlayer({ stream = null, torrentIdentifier = "", infoHash = "" }:
     const handleError = (torrentError: Error) => {
       if (!isMounted) return;
       clearNoPeersTimeout();
-      setError(torrentError.message || "Unable to load this torrent.");
+      const errorMessage = torrentError.message || "Unable to load this torrent.";
+      setError(errorMessage);
       setStatus("error");
+      onPlaybackError?.(errorMessage);
     };
 
     const handleNoWebRtcPeers = () => {
@@ -147,10 +185,54 @@ function TorrentPlayer({ stream = null, torrentIdentifier = "", infoHash = "" }:
 
     client.on("error", handleClientError);
 
+    const attachVideoElement = () => {
+      const videoElement = containerRef.current?.querySelector("video") as HTMLVideoElement | null;
+      if (!videoElement || !isMounted) return;
+
+      activeVideoElement = videoElement;
+      activeVideoElement.controls = true;
+      activeVideoElement.autoplay = true;
+      activeVideoElement.playsInline = true;
+      if (poster) activeVideoElement.poster = poster;
+      if (title) activeVideoElement.title = title;
+      if (playerRef) playerRef.current = activeVideoElement;
+
+      const handleLoadedMetadata = () => onLoadedMetadata?.();
+      const handleTimeUpdate = () => onTimeUpdate?.();
+      const handlePause = () => onPause?.();
+      const handleEnded = () => onEnded?.();
+      const handleReady = () => {
+        clearNoPeersTimeout();
+        onPlaybackReady?.();
+      };
+      const handleVideoError = () => {
+        const videoErrorMessage = activeVideoElement?.error?.message || "Unable to play this torrent video.";
+        handleError(new Error(videoErrorMessage));
+      };
+
+      activeVideoElement.addEventListener("loadedmetadata", handleLoadedMetadata);
+      activeVideoElement.addEventListener("timeupdate", handleTimeUpdate);
+      activeVideoElement.addEventListener("pause", handlePause);
+      activeVideoElement.addEventListener("ended", handleEnded);
+      activeVideoElement.addEventListener("canplay", handleReady);
+      activeVideoElement.addEventListener("play", handleReady);
+      activeVideoElement.addEventListener("error", handleVideoError);
+
+      cleanupVideoListeners = () => {
+        activeVideoElement?.removeEventListener("loadedmetadata", handleLoadedMetadata);
+        activeVideoElement?.removeEventListener("timeupdate", handleTimeUpdate);
+        activeVideoElement?.removeEventListener("pause", handlePause);
+        activeVideoElement?.removeEventListener("ended", handleEnded);
+        activeVideoElement?.removeEventListener("canplay", handleReady);
+        activeVideoElement?.removeEventListener("play", handleReady);
+        activeVideoElement?.removeEventListener("error", handleVideoError);
+      };
+    };
+
     const torrent = client.add(torrentId, (addedTorrent) => {
       markUsefulTorrentActivity();
 
-      const videoFile = addedTorrent.files.find((file: WebTorrentFile) => /\.(mp4|webm)$/i.test(file.name));
+      const videoFile = selectPlayableVideoFile(addedTorrent.files);
 
       if (!videoFile) {
         handleError(new Error("No .mp4 or .webm file was found in this torrent."));
@@ -166,8 +248,10 @@ function TorrentPlayer({ stream = null, torrentIdentifier = "", infoHash = "" }:
         }
 
         if (!isMounted) return;
+        attachVideoElement();
         clearNoPeersTimeout();
         setStatus("ready");
+        onPlaybackReady?.();
       });
     });
 
@@ -193,10 +277,14 @@ function TorrentPlayer({ stream = null, torrentIdentifier = "", infoHash = "" }:
     return () => {
       isMounted = false;
       clearNoPeersTimeout();
+      cleanupVideoListeners();
+      if (playerRef && playerRef.current === activeVideoElement) {
+        playerRef.current = null;
+      }
       container.replaceChildren();
       client.destroy();
     };
-  }, [torrentId]);
+  }, [onEnded, onLoadedMetadata, onPause, onPlaybackError, onPlaybackReady, onTimeUpdate, playerRef, poster, reloadToken, title, torrentId]);
 
   const isLoading = status === "connecting" || status === "downloading";
 

--- a/src/hooks/useTorrentio.ts
+++ b/src/hooks/useTorrentio.ts
@@ -114,7 +114,13 @@ export const selectBestTorrentioStream = (
   };
 };
 
-function useTorrentio(tmdbId?: string | number | null, type?: TorrentioMediaType | null): UseTorrentioState {
+function useTorrentio(
+  tmdbId?: string | number | null,
+  type?: TorrentioMediaType | null,
+  season?: string | number | null,
+  episode?: string | number | null,
+  refreshKey = 0,
+): UseTorrentioState {
   const [stream, setStream] = useState<TorrentioStreamMetadata | null>(null);
   const [imdbId, setImdbId] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -122,9 +128,15 @@ function useTorrentio(tmdbId?: string | number | null, type?: TorrentioMediaType
 
   const normalizedTmdbId = useMemo(() => String(tmdbId || "").trim(), [tmdbId]);
   const normalizedType = type === "tv" ? "tv" : type === "movie" ? "movie" : "";
+  const normalizedSeason = useMemo(() => String(season || "").trim(), [season]);
+  const normalizedEpisode = useMemo(() => String(episode || "").trim(), [episode]);
 
   useEffect(() => {
-    if (!normalizedTmdbId || !normalizedType) {
+    if (
+      !normalizedTmdbId ||
+      !normalizedType ||
+      (normalizedType === "tv" && (!normalizedSeason || !normalizedEpisode))
+    ) {
       setStream(null);
       setImdbId("");
       setIsLoading(false);
@@ -153,7 +165,12 @@ function useTorrentio(tmdbId?: string | number | null, type?: TorrentioMediaType
 
       setImdbId(resolvedImdbId);
 
-      const response = await fetch(`https://torrentio.strem.fun/stream/${normalizedType}/${resolvedImdbId}.json`, {
+      const torrentioType = normalizedType === "tv" ? "series" : "movie";
+      const torrentioId = normalizedType === "tv"
+        ? `${resolvedImdbId}:${normalizedSeason}:${normalizedEpisode}`
+        : resolvedImdbId;
+
+      const response = await fetch(`https://torrentio.strem.fun/stream/${torrentioType}/${torrentioId}.json`, {
         signal: controller.signal,
       });
 
@@ -189,7 +206,7 @@ function useTorrentio(tmdbId?: string | number | null, type?: TorrentioMediaType
       isCancelled = true;
       controller.abort();
     };
-  }, [normalizedTmdbId, normalizedType]);
+  }, [normalizedEpisode, normalizedSeason, normalizedTmdbId, normalizedType, refreshKey]);
 
   return {
     stream,

--- a/src/pages/video/Watch.tsx
+++ b/src/pages/video/Watch.tsx
@@ -27,6 +27,7 @@ import { useStream } from "../../context/Stream";
 import { useUsers } from "../../context/Users";
 import { User } from "../../user";
 import PlaybackSurface from "../../components/player/PlaybackSurface";
+import TorrentPlayer from "../../components/player/TorrentPlayer";
 import { playbackAPI } from "../../service/api/smb/playback.api.service";
 import RatingDialog from "../../components/library/RatingDialog";
 import { ProviderId, ProviderSourceFormat } from "../../types/providers";
@@ -34,6 +35,7 @@ import DownloadButton from "../../components/player/DownloadButton";
 import { copyToClipboard } from "../../utilities/defaults";
 import { watchPartyAPI } from "../../service/api/smb/watchparty.api.service";
 import toast from "react-hot-toast";
+import useTorrentio from "../../hooks/useTorrentio";
 
 const AUTO_SAVE_INTERVAL_MS = 60000;
 const MIN_PROGRESS_DELTA_MINUTES = 1;
@@ -44,15 +46,17 @@ const LOCAL_ROUTE_PROGRESS_PREFIX = "watch-progress:";
 const LOCAL_RECENT_PROGRESS_PREFIX = "recent-progress:";
 const PROVIDER_PARAM_KEY = "provider";
 const SERVER_PARAM_KEY = "server";
-const PROVIDER_OPTIONS: ProviderId[] = ["vixsrc", "showbox", "anikai"];
+const PROVIDER_OPTIONS: ProviderId[] = ["vixsrc", "showbox", "anikai", "torrentio"];
 
 const parseProviderFromQuery = (value: string | null): ProviderId => {
   if (value === "anikai") return "anikai";
+  if (value === "torrentio" || value === "torrentplayer") return "torrentio";
   return value === "showbox" ? "showbox" : "vixsrc";
 };
 
 const getProviderLabel = (provider: ProviderId) => {
   if (provider === "anikai") return "Anikai";
+  if (provider === "torrentio") return "TorrentPlayer";
   return provider === "showbox" ? "ShowBox" : "Vixsrc";
 };
 
@@ -96,7 +100,7 @@ const readStoredRecentProgress = (key: string): LocalRecentProgress | null => {
     const rawValue = window.localStorage.getItem(key);
     if (!rawValue) return null;
     return JSON.parse(rawValue) as LocalRecentProgress;
-  } catch (_error) {
+  } catch {
     return null;
   }
 };
@@ -125,7 +129,7 @@ function Watch() {
   const { getStreamData, getStream } = useStream();
   const { deleteRating, myselfData, upsertRecentlyWatched, upsertRating } = useUsers();
   const navigate = useNavigate();
-  const playerRef = useRef<any>(null);
+  const playerRef = useRef<HTMLVideoElement | null>(null);
   const playbackReadyRef = useRef(false);
   const progressRef = useRef({
     lastFlushedAt: 0,
@@ -210,26 +214,49 @@ function Watch() {
   // Clip sharing
   const [clipCopied, setClipCopied] = useState(false);
   const selectedProvider = parseProviderFromQuery(searchParams.get(PROVIDER_PARAM_KEY));
+  const isTorrentProvider = selectedProvider === "torrentio";
+  const isTorrentPlayback = isTorrentProvider && searchParams.get("offline") !== "1";
+  const torrentioData = useTorrentio(
+    isTorrentPlayback ? movieId : null,
+    isTorrentPlayback && (movieType === "movie" || movieType === "tv") ? movieType : null,
+    seasonId,
+    episodeId,
+    playerReloadToken,
+  );
   const versionParam = searchParams.get("version") as "sub" | "dub" | null;
   const version = versionParam === "dub" ? "dub" : "sub";
   const selectedServerFromQuery = String(searchParams.get(SERVER_PARAM_KEY) || "").trim();
-  const availableStream = getStreamData.data?.stream || null;
-  const resolvedProvider = getStreamData.data?.resolvedProvider || selectedProvider;
-  const providerNotice = String(getStreamData.data?.message || "").trim();
-  const availableSources = availableStream?.sources || [];
+  const availableStream = isTorrentProvider ? null : getStreamData.data?.stream || null;
+  const resolvedProvider = isTorrentProvider ? selectedProvider : getStreamData.data?.resolvedProvider || selectedProvider;
+  const providerNotice = isTorrentProvider
+    ? torrentioData.stream
+      ? `TorrentPlayer selected: ${torrentioData.stream.filename || torrentioData.stream.title}`
+      : ""
+    : String(getStreamData.data?.message || "").trim();
+  const availableSources = isTorrentProvider ? [] : availableStream?.sources || [];
   const activeSource =
     availableSources.find((source) => source.id === selectedServerFromQuery) ||
     availableSources.find((source) => source.active) ||
     availableSources[0] ||
     null;
   const playbackStream = useMemo(() => (sessionBaseReady ? availableStream : null), [availableStream, sessionBaseReady]);
-  const playbackSourceUrl = useMemo(
+  const providerPlaybackSourceUrl = useMemo(
     () =>
       sessionBaseReady
         ? activeSource?.url || availableStream?.masterPlaylistUrl || ""
         : "",
     [activeSource?.url, availableStream?.masterPlaylistUrl, sessionBaseReady],
   );
+  const torrentPlaybackSourceUrl = useMemo(
+    () =>
+      sessionBaseReady && torrentioData.stream?.infoHash
+        ? `torrent:${torrentioData.stream.infoHash}`
+        : "",
+    [sessionBaseReady, torrentioData.stream?.infoHash],
+  );
+  const playbackSourceUrl = isTorrentPlayback
+    ? torrentPlaybackSourceUrl
+    : providerPlaybackSourceUrl;
 
   // Offline playback — load from Cache API when ?offline=1
   const offlineParam = searchParams.get("offline") === "1";
@@ -261,21 +288,26 @@ function Watch() {
     () =>
       activeSource?.format
         ? activeSource.format
-        : inferFormatFromUrl(playbackSourceUrl),
-    [activeSource?.format, playbackSourceUrl],
+        : inferFormatFromUrl(providerPlaybackSourceUrl),
+    [activeSource?.format, providerPlaybackSourceUrl],
   );
-  const isPreparingPlayback = getStreamData.isLoading;
-  const isPlaybackUnavailable =
-    !isPreparingPlayback &&
-    sessionBaseReady &&
-    !getStreamData.isAvailable &&
-    getStreamData.provider === selectedProvider;
+  const isPreparingPlayback = isTorrentPlayback ? torrentioData.isLoading : getStreamData.isLoading;
+  const isPlaybackUnavailable = isTorrentPlayback
+    ? !isPreparingPlayback && sessionBaseReady && !torrentioData.stream
+    : !isPreparingPlayback &&
+      sessionBaseReady &&
+      !getStreamData.isAvailable &&
+      getStreamData.provider === selectedProvider;
   const activeSourceIndex = activeSource
     ? availableSources.findIndex((source) => source.id === activeSource.id)
     : -1;
   const nextSourceOption =
     activeSourceIndex >= 0 ? availableSources[activeSourceIndex + 1] || null : null;
-  const serverLabel = activeSource?.name || "No server selected";
+  const serverLabel = isTorrentProvider
+    ? torrentioData.stream
+      ? `${torrentioData.stream.seeds.toLocaleString()} seeds`
+      : "Torrent metadata"
+    : activeSource?.name || "No server selected";
   const failoverContextKey = `${selectedProvider}:${movieType || ""}:${movieId || ""}:${seasonId || 0}:${episodeId || 0}`;
   const autoFailoverStateRef = useRef({
     contextKey: "",
@@ -283,7 +315,9 @@ function Watch() {
   });
   const centerErrorMessage = String(
     isPlaybackUnavailable
-      ? getStreamData.errorMessage || "Unable to load stream for this provider/server."
+      ? isTorrentPlayback
+        ? torrentioData.error || "Unable to load a TorrentPlayer stream for this title."
+        : getStreamData.errorMessage || "Unable to load stream for this provider/server."
       : lastPlaybackError,
   ).trim();
 
@@ -443,14 +477,16 @@ function Watch() {
       season: seasonId ? parseInt(seasonId) : 0,
       episode: episodeId ? parseInt(episodeId) : 0,
       title: mediaTitle,
-      playerKind: "provider_modern",
-      sourceType: "provider_stream",
-      fallbackReason: `provider:${selectedProvider};server:${activeSource?.id || "default"}`,
+      playerKind: isTorrentProvider ? "torrentplayer" : "provider_modern",
+      sourceType: isTorrentProvider ? "torrent_stream" : "provider_stream",
+      fallbackReason: isTorrentProvider
+        ? `provider:torrentio;infoHash:${torrentioData.infoHash || "pending"}`
+        : `provider:${selectedProvider};server:${activeSource?.id || "default"}`,
       lastPosition: progressMinutes,
       duration: resolvedDuration,
       completionRatio,
     };
-  }, [activeSource?.id, episodeId, fallbackDurationMinutes, mediaTitle, movieId, movieType, seasonId, selectedProvider]);
+  }, [activeSource?.id, episodeId, fallbackDurationMinutes, isTorrentProvider, mediaTitle, movieId, movieType, seasonId, selectedProvider, torrentioData.infoHash]);
 
   const syncPlaybackTelemetry = useCallback(async (
     progressMinutes: number,
@@ -470,7 +506,7 @@ function Watch() {
       }
 
       await playbackAPI.heartbeat(playbackSessionRef.current.id, payload);
-    } catch (_error) {
+    } catch {
       // Best effort only.
     }
   }, [getPlaybackSessionPayload, isLoggedIn]);
@@ -720,7 +756,9 @@ function Watch() {
     if (movieType === "movie") {
       movie(movieId);
       movieImages(movieId);
-      getStream(selectedProvider, "movie", movieId, undefined, undefined, selectedProvider === "anikai" ? version : undefined);
+      if (!isTorrentProvider) {
+        getStream(selectedProvider, "movie", movieId, undefined, undefined, selectedProvider === "anikai" ? version : undefined);
+      }
       return;
     }
 
@@ -729,10 +767,10 @@ function Watch() {
     if (seasonId) {
       tvSeasonsDetails(movieId, parseInt(seasonId));
     }
-    if (seasonId && episodeId) {
+    if (seasonId && episodeId && !isTorrentProvider) {
       getStream(selectedProvider, "tv", movieId, seasonId, episodeId, selectedProvider === "anikai" ? version : undefined);
     }
-  }, [episodeId, movieId, movieType, seasonId, selectedProvider, version]);
+  }, [episodeId, isTorrentProvider, movieId, movieType, seasonId, selectedProvider, version]);
 
   useEffect(() => {
     if (!sessionBaseReady) return;
@@ -902,7 +940,7 @@ function Watch() {
   }, [getPlayerDurationMinutes, persistProgress]);
 
   const requestStream = () => {
-    if (!movieId || !movieType) return;
+    if (!movieId || !movieType || isTorrentProvider) return;
 
     if (movieType === "movie") {
       void getStream(selectedProvider, "movie", movieId, undefined, undefined, selectedProvider === "anikai" ? version : undefined);
@@ -943,6 +981,11 @@ function Watch() {
 
   const retryCurrentServer = () => {
     setLastPlaybackError("");
+
+    if (isTorrentProvider) {
+      setPlayerReloadToken((value) => value + 1);
+      return;
+    }
 
     if (selectedProvider === "showbox") {
       autoFailoverStateRef.current = {
@@ -1167,12 +1210,18 @@ function Watch() {
         <Select
           size="sm"
           value={activeSource?.id || null}
-          placeholder={availableSources.length ? "Select server" : "No servers yet"}
+          placeholder={isTorrentProvider
+            ? torrentioData.stream
+              ? "Best Torrentio stream"
+              : "Finding torrent"
+            : availableSources.length
+              ? "Select server"
+              : "No servers yet"}
           onChange={(_e, value) => {
             if (!value) return;
             setServerInQuery(String(value));
           }}
-          disabled={!availableSources.length}
+          disabled={isTorrentProvider || !availableSources.length}
           sx={{
             minWidth: { xs: "200px", sm: "260px" },
             maxWidth: "100%",
@@ -1274,21 +1323,37 @@ function Watch() {
           </Select>
         </Box>
       ) : null}
-      <PlaybackSurface
-        playerRef={playerRef}
-        stream={offlineParam ? null : playbackStream}
-        sourceUrl={offlineParam && offlineBlobUrl ? offlineBlobUrl : playbackSourceUrl}
-        sourceFormat={offlineParam ? "mp4" : playbackSourceFormat}
-        poster={backdropPoster}
-        title={mediaTitle}
-        onLoadedMetadata={handlePlayerLoadedMetadata}
-        onTimeUpdate={handlePlayerTimeUpdate}
-        onPause={handlePlayerPause}
-        onEnded={handlePlayerEnded}
-        onPlaybackError={handlePlaybackError}
-        onPlaybackReady={handlePlaybackReady}
-        reloadToken={playerReloadToken}
-      />
+      {isTorrentPlayback ? (
+        <TorrentPlayer
+          stream={torrentioData.stream}
+          playerRef={playerRef}
+          poster={backdropPoster}
+          title={mediaTitle}
+          onLoadedMetadata={handlePlayerLoadedMetadata}
+          onTimeUpdate={handlePlayerTimeUpdate}
+          onPause={handlePlayerPause}
+          onEnded={handlePlayerEnded}
+          onPlaybackError={handlePlaybackError}
+          onPlaybackReady={handlePlaybackReady}
+          reloadToken={playerReloadToken}
+        />
+      ) : (
+        <PlaybackSurface
+          playerRef={playerRef}
+          stream={offlineParam ? null : playbackStream}
+          sourceUrl={offlineParam && offlineBlobUrl ? offlineBlobUrl : providerPlaybackSourceUrl}
+          sourceFormat={offlineParam ? "mp4" : playbackSourceFormat}
+          poster={backdropPoster}
+          title={mediaTitle}
+          onLoadedMetadata={handlePlayerLoadedMetadata}
+          onTimeUpdate={handlePlayerTimeUpdate}
+          onPause={handlePlayerPause}
+          onEnded={handlePlayerEnded}
+          onPlaybackError={handlePlaybackError}
+          onPlaybackReady={handlePlaybackReady}
+          reloadToken={playerReloadToken}
+        />
+      )}
       {centerErrorMessage ? (
         <Box
           sx={{

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -1,6 +1,6 @@
 export type VixsrcMediaType = "movie" | "tv";
 export type VixsrcAvailabilityMatch = "movie" | "tv" | "episode" | null;
-export type ProviderId = "vixsrc" | "showbox" | "anikai";
+export type ProviderId = "vixsrc" | "showbox" | "anikai" | "torrentio";
 export type AnimeMode = "sub" | "dub";
 export type ProviderSourceFormat = "hls" | "mp4" | "unknown";
 

--- a/src/types/webtorrent.d.ts
+++ b/src/types/webtorrent.d.ts
@@ -5,6 +5,7 @@ declare module "webtorrent/dist/webtorrent.min.js" {
 
   export type WebTorrentFile = {
     name: string;
+    length?: number;
     appendTo: (
       rootElement: HTMLElement,
       options?: {


### PR DESCRIPTION
### Motivation

- Add support for torrent-based playback (Torrentio/TorrentPlayer) on the Watch page so users can play seeded .mp4/.webm torrents directly in the same watch experience. 
- Keep existing playback telemetry, progress saving and watch-page UX consistent when using torrent playback.

### Description

- Add `torrentio` to the provider enum and provider dropdown, accept `provider=torrentio`/`provider=torrentplayer` in the query, and surface a `TorrentPlayer` label in the UI.  
- Extend `useTorrentio` to resolve Torrentio metadata for movies and TV episodes (uses Torrentio `series` endpoint for TV) and accept season/episode inputs plus a refresh key for reloads.  
- Replace the single playback surface branch in `Watch.tsx` with a conditional that renders `TorrentPlayer` when `provider=torrentio` (forwarding `playerRef`, poster/title, reload token and playback event callbacks) and otherwise renders the existing `PlaybackSurface`.  
- Update telemetry/session payloads to record torrent sessions (`playerKind:

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19f9ccccfc832cb40ef4a21a375cca)