### PR TITLE
Add torrent stream bridge for playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,21 @@ MIT License. See [`LICENSE`](./LICENSE) for details.
 ---
 
 Made with ❤️ for film lovers, by Usmon.
+
+## Torrent playback in development
+
+The in-browser TorrentPlayer can only connect to WebRTC torrent peers. A Torrentio result can show many seeders and still fail in a browser when those seeders are regular BitTorrent TCP/UDP peers instead of WebRTC peers.
+
+For reliable local playback, run the included HTTP torrent bridge in a separate terminal:
+
+```bash
+npm run torrent:server
+```
+
+Then start the Vite app with the bridge URL available to the frontend:
+
+```bash
+VITE_TORRENT_STREAM_BASE_URL=http://127.0.0.1:8787 npm run dev
+```
+
+The bridge downloads through the normal Node/WebTorrent engine and exposes a ranged HTTP video endpoint to the browser, so the watch page can play it with a standard `<video>` element.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "torrent:server": "node scripts/torrent-stream-server.mjs"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/scripts/torrent-stream-server.mjs
+++ b/scripts/torrent-stream-server.mjs
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+import http from "node:http";
+import process from "node:process";
+import { URL } from "node:url";
+import WebTorrent from "webtorrent";
+
+const PORT = Number.parseInt(process.env.TORRENT_STREAM_PORT || "8787", 10);
+const HOST = process.env.TORRENT_STREAM_HOST || "127.0.0.1";
+const METADATA_TIMEOUT_MS = Number.parseInt(process.env.TORRENT_METADATA_TIMEOUT_MS || "45000", 10);
+const DEFAULT_TRACKERS = [
+  "udp://tracker.opentrackr.org:1337/announce",
+  "udp://open.stealth.si:80/announce",
+  "udp://tracker.torrent.eu.org:451/announce",
+  "udp://tracker.bittor.pw:1337/announce",
+  "udp://public.popcorn-tracker.org:6969/announce",
+  "wss://tracker.btorrent.xyz",
+  "wss://tracker.openwebtorrent.com",
+  "wss://tracker.fastcast.nz",
+];
+const MIME_TYPES = new Map([
+  [".mp4", "video/mp4"],
+  [".m4v", "video/mp4"],
+  [".webm", "video/webm"],
+  [".mkv", "video/x-matroska"],
+]);
+
+const client = new WebTorrent();
+const pendingTorrents = new Map();
+
+const json = (response, statusCode, body) => {
+  response.writeHead(statusCode, {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET,HEAD,OPTIONS",
+    "Access-Control-Allow-Headers": "Range,Content-Type",
+    "Content-Type": "application/json; charset=utf-8",
+  });
+  response.end(JSON.stringify(body));
+};
+
+const setCorsHeaders = (response) => {
+  response.setHeader("Access-Control-Allow-Origin", "*");
+  response.setHeader("Access-Control-Allow-Methods", "GET,HEAD,OPTIONS");
+  response.setHeader("Access-Control-Allow-Headers", "Range,Content-Type");
+  response.setHeader("Access-Control-Expose-Headers", "Content-Length,Content-Range,Accept-Ranges");
+};
+
+const normalizeInfoHash = (value) => String(value || "").trim().replace(/^urn:btih:/i, "").replace(/^btih:/i, "");
+
+const isInfoHash = (value) => /^[a-z0-9]{32,40}$/i.test(normalizeInfoHash(value));
+
+const ensureTrackers = (magnetUri, extraTrackers = []) => {
+  const url = new URL(magnetUri);
+  const trackers = new Set(url.searchParams.getAll("tr").map((tracker) => tracker.trim()).filter(Boolean));
+  [...DEFAULT_TRACKERS, ...extraTrackers].forEach((tracker) => trackers.add(tracker));
+  url.searchParams.delete("tr");
+  trackers.forEach((tracker) => url.searchParams.append("tr", tracker));
+  return url.toString();
+};
+
+const createMagnetUri = (infoHash, extraTrackers = []) => {
+  const params = new URLSearchParams({ xt: `urn:btih:${normalizeInfoHash(infoHash)}` });
+  [...DEFAULT_TRACKERS, ...extraTrackers].forEach((tracker) => params.append("tr", tracker));
+  return `magnet:?${params.toString()}`;
+};
+
+const torrentIdFromRequest = (infoHash, searchParams) => {
+  const magnet = String(searchParams.get("magnet") || "").trim();
+  const trackers = searchParams.getAll("tr");
+
+  if (magnet.toLowerCase().startsWith("magnet:?")) {
+    return ensureTrackers(magnet, trackers);
+  }
+
+  return createMagnetUri(infoHash, trackers);
+};
+
+const waitForTorrent = (infoHash, torrentId) => {
+  const key = normalizeInfoHash(infoHash).toLowerCase();
+  const existingTorrent = client.get(key);
+  if (existingTorrent?.files?.length) {
+    return Promise.resolve(existingTorrent);
+  }
+
+  const pendingTorrent = pendingTorrents.get(key);
+  if (pendingTorrent) {
+    return pendingTorrent;
+  }
+
+  const promise = new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`Timed out waiting for torrent metadata after ${METADATA_TIMEOUT_MS / 1000}s.`));
+    }, METADATA_TIMEOUT_MS);
+
+    const torrent = existingTorrent || client.add(torrentId);
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      torrent.off("ready", handleReady);
+      torrent.off("metadata", handleReady);
+      torrent.off("error", handleError);
+      pendingTorrents.delete(key);
+    };
+    const handleReady = () => {
+      cleanup();
+      resolve(torrent);
+    };
+    const handleError = (error) => {
+      cleanup();
+      reject(error);
+    };
+
+    if (torrent.files?.length) {
+      handleReady();
+      return;
+    }
+
+    torrent.once("ready", handleReady);
+    torrent.once("metadata", handleReady);
+    torrent.once("error", handleError);
+  });
+
+  pendingTorrents.set(key, promise);
+  return promise;
+};
+
+const extensionFor = (filename) => {
+  const match = String(filename || "").toLowerCase().match(/\.[^.]+$/);
+  return match?.[0] || "";
+};
+
+const isBrowserPlayable = (file) => [".mp4", ".m4v", ".webm"].includes(extensionFor(file.name));
+
+const chooseVideoFile = (files, requestedFilename) => {
+  const videos = files.filter((file) => MIME_TYPES.has(extensionFor(file.name)));
+  const exactMatch = videos.find((file) => requestedFilename && file.name.endsWith(requestedFilename));
+
+  return exactMatch || videos.filter(isBrowserPlayable).sort((a, b) => b.length - a.length)[0] || videos.sort((a, b) => b.length - a.length)[0];
+};
+
+const parseRange = (rangeHeader, fileLength) => {
+  if (!rangeHeader) {
+    return { statusCode: 200, start: 0, end: fileLength - 1 };
+  }
+
+  const match = String(rangeHeader).match(/^bytes=(\d*)-(\d*)$/);
+  if (!match) {
+    return null;
+  }
+
+  const [, rawStart, rawEnd] = match;
+  let start = rawStart ? Number.parseInt(rawStart, 10) : 0;
+  let end = rawEnd ? Number.parseInt(rawEnd, 10) : fileLength - 1;
+
+  if (!rawStart && rawEnd) {
+    const suffixLength = Number.parseInt(rawEnd, 10);
+    start = Math.max(fileLength - suffixLength, 0);
+    end = fileLength - 1;
+  }
+
+  if (!Number.isFinite(start) || !Number.isFinite(end) || start > end || start >= fileLength) {
+    return null;
+  }
+
+  return { statusCode: 206, start, end: Math.min(end, fileLength - 1) };
+};
+
+const handleStream = async (request, response, url) => {
+  const [, , rawInfoHash] = url.pathname.split("/");
+  const infoHash = normalizeInfoHash(decodeURIComponent(rawInfoHash || ""));
+
+  if (!isInfoHash(infoHash)) {
+    json(response, 400, { error: "A valid torrent info hash is required." });
+    return;
+  }
+
+  const torrent = await waitForTorrent(infoHash, torrentIdFromRequest(infoHash, url.searchParams));
+  const file = chooseVideoFile(torrent.files, url.searchParams.get("filename"));
+
+  if (!file) {
+    json(response, 404, { error: "No playable video file was found in this torrent." });
+    return;
+  }
+
+  const range = parseRange(request.headers.range, file.length);
+  if (!range) {
+    setCorsHeaders(response);
+    response.writeHead(416, { "Content-Range": `bytes */${file.length}` });
+    response.end();
+    return;
+  }
+
+  const contentLength = range.end - range.start + 1;
+  const headers = {
+    "Accept-Ranges": "bytes",
+    "Content-Length": contentLength,
+    "Content-Type": MIME_TYPES.get(extensionFor(file.name)) || "application/octet-stream",
+    "Content-Disposition": `inline; filename*=UTF-8''${encodeURIComponent(file.name)}`,
+  };
+
+  if (range.statusCode === 206) {
+    headers["Content-Range"] = `bytes ${range.start}-${range.end}/${file.length}`;
+  }
+
+  setCorsHeaders(response);
+  response.writeHead(range.statusCode, headers);
+
+  if (request.method === "HEAD") {
+    response.end();
+    return;
+  }
+
+  const stream = file.createReadStream({ start: range.start, end: range.end });
+  request.on("close", () => stream.destroy());
+  stream.on("error", (error) => {
+    if (!response.headersSent) {
+      json(response, 500, { error: error.message || "Torrent stream failed." });
+      return;
+    }
+
+    response.destroy(error);
+  });
+  stream.pipe(response);
+};
+
+const server = http.createServer((request, response) => {
+  const url = new URL(request.url || "/", `http://${request.headers.host || `${HOST}:${PORT}`}`);
+
+  if (request.method === "OPTIONS") {
+    setCorsHeaders(response);
+    response.writeHead(204);
+    response.end();
+    return;
+  }
+
+  if (url.pathname === "/health") {
+    json(response, 200, { ok: true });
+    return;
+  }
+
+  if ((request.method === "GET" || request.method === "HEAD") && url.pathname.startsWith("/stream/")) {
+    handleStream(request, response, url).catch((error) => {
+      console.error(error);
+      json(response, 500, { error: error.message || "Failed to open torrent stream." });
+    });
+    return;
+  }
+
+  json(response, 404, { error: "Not found" });
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`Torrent stream server listening at http://${HOST}:${PORT}`);
+});
+
+const shutdown = () => {
+  server.close(() => {
+    client.destroy(() => process.exit(0));
+  });
+};
+
+process.once("SIGINT", shutdown);
+process.once("SIGTERM", shutdown);

--- a/src/components/player/TorrentPlayer.tsx
+++ b/src/components/player/TorrentPlayer.tsx
@@ -11,7 +11,8 @@ const WEBRTC_TRACKERS = [
 
 const NO_WEBRTC_PEERS_TIMEOUT_MS = 20_000;
 const NO_WEBRTC_PEERS_MESSAGE =
-  "No WebRTC peers were found for this torrent. Try another stream or check back later.";
+  "No browser-compatible WebRTC peers were found. The stream has normal torrent seeders, but browsers can only reach WebRTC peers. Run the torrent stream server or try another stream.";
+const TORRENT_STREAM_BASE_URL = String(import.meta.env.VITE_TORRENT_STREAM_BASE_URL || "").trim();
 
 type TorrentPlayerProps = {
   stream?: TorrentioStreamMetadata | null;
@@ -96,6 +97,21 @@ const resolveTorrentIdentifier = ({ stream, torrentIdentifier, infoHash }: Torre
   return isBareInfoHash(preferredIdentifier) ? createMagnetUri(preferredIdentifier) : preferredIdentifier;
 };
 
+const buildServerStreamUrl = (stream: TorrentioStreamMetadata | null, torrentId: string) => {
+  const normalizedBaseUrl = TORRENT_STREAM_BASE_URL.replace(/\/+$/g, "");
+  const infoHash = normalizeInfoHash(stream?.infoHash || (isBareInfoHash(torrentId) ? torrentId : ""));
+
+  if (!normalizedBaseUrl || !infoHash) {
+    return "";
+  }
+
+  const url = new URL(`${normalizedBaseUrl}/stream/${encodeURIComponent(infoHash)}`);
+  if (stream?.filename) url.searchParams.set("filename", stream.filename);
+  if (stream?.url) url.searchParams.set("magnet", stream.url);
+
+  return url.toString();
+};
+
 const selectPlayableVideoFile = (files: WebTorrentFile[]) => {
   const playableFiles = files.filter((file) => PLAYABLE_VIDEO_PATTERN.test(file.name));
 
@@ -127,10 +143,11 @@ function TorrentPlayer({
     () => resolveTorrentIdentifier({ stream, torrentIdentifier, infoHash }),
     [infoHash, stream, torrentIdentifier],
   );
+  const serverStreamUrl = useMemo(() => buildServerStreamUrl(stream, torrentId), [stream, torrentId]);
 
   useEffect(() => {
     const container = containerRef.current;
-    if (!container || !torrentId) {
+    if (!container || (!torrentId && !serverStreamUrl)) {
       setStatus("idle");
       if (playerRef) playerRef.current = null;
       return;
@@ -142,7 +159,7 @@ function TorrentPlayer({
     let latestTrackerWarning = "";
     let activeVideoElement: HTMLVideoElement | null = null;
     let cleanupVideoListeners = () => {};
-    const client = new WebTorrent();
+    let client: WebTorrent | null = null;
 
     container.replaceChildren();
     if (playerRef) playerRef.current = null;
@@ -183,11 +200,8 @@ function TorrentPlayer({
       handleError(torrentError instanceof Error ? torrentError : new Error(String(torrentError)));
     };
 
-    client.on("error", handleClientError);
-
-    const attachVideoElement = () => {
-      const videoElement = containerRef.current?.querySelector("video") as HTMLVideoElement | null;
-      if (!videoElement || !isMounted) return;
+    const attachVideoElement = (videoElement: HTMLVideoElement) => {
+      if (!isMounted) return;
 
       activeVideoElement = videoElement;
       activeVideoElement.controls = true;
@@ -203,6 +217,7 @@ function TorrentPlayer({
       const handleEnded = () => onEnded?.();
       const handleReady = () => {
         clearNoPeersTimeout();
+        setStatus("ready");
         onPlaybackReady?.();
       };
       const handleVideoError = () => {
@@ -229,6 +244,33 @@ function TorrentPlayer({
       };
     };
 
+    if (serverStreamUrl) {
+      const videoElement = document.createElement("video");
+      videoElement.src = serverStreamUrl;
+      videoElement.preload = "auto";
+      videoElement.autoplay = true;
+      videoElement.controls = true;
+      videoElement.playsInline = true;
+      container.append(videoElement);
+      attachVideoElement(videoElement);
+      videoElement.play().catch(() => undefined);
+
+      return () => {
+        isMounted = false;
+        cleanupVideoListeners();
+        if (playerRef && playerRef.current === activeVideoElement) {
+          playerRef.current = null;
+        }
+        videoElement.pause();
+        videoElement.removeAttribute("src");
+        videoElement.load();
+        container.replaceChildren();
+      };
+    }
+
+    client = new WebTorrent();
+    client.on("error", handleClientError);
+
     const torrent = client.add(torrentId, (addedTorrent) => {
       markUsefulTorrentActivity();
 
@@ -247,8 +289,9 @@ function TorrentPlayer({
           return;
         }
 
-        if (!isMounted) return;
-        attachVideoElement();
+        const videoElement = containerRef.current?.querySelector("video") as HTMLVideoElement | null;
+        if (!isMounted || !videoElement) return;
+        attachVideoElement(videoElement);
         clearNoPeersTimeout();
         setStatus("ready");
         onPlaybackReady?.();
@@ -282,9 +325,9 @@ function TorrentPlayer({
         playerRef.current = null;
       }
       container.replaceChildren();
-      client.destroy();
+      client?.destroy();
     };
-  }, [onEnded, onLoadedMetadata, onPause, onPlaybackError, onPlaybackReady, onTimeUpdate, playerRef, poster, reloadToken, title, torrentId]);
+  }, [onEnded, onLoadedMetadata, onPause, onPlaybackError, onPlaybackReady, onTimeUpdate, playerRef, poster, reloadToken, serverStreamUrl, title, torrentId]);
 
   const isLoading = status === "connecting" || status === "downloading";
 
@@ -324,10 +367,10 @@ function TorrentPlayer({
         >
           <LinearProgress determinate={status === "downloading"} value={progress} thickness={2} />
           <Typography level="h4" sx={{ mt: 2 }}>
-            {status === "connecting" ? "Finding peers" : `Buffering torrent (${progress.toFixed(1)}%)`}
+            {status === "connecting" ? "Opening torrent stream" : `Buffering torrent (${progress.toFixed(1)}%)`}
           </Typography>
           <Typography level="body-sm" sx={{ mt: 1, color: "neutral.400" }}>
-            Download speed: {bytesPerSecondLabel(downloadSpeed)}
+            {serverStreamUrl ? "Using torrent stream server" : `Download speed: ${bytesPerSecondLabel(downloadSpeed)}`}
           </Typography>
         </Box>
       ) : null}


### PR DESCRIPTION
### Motivation
- Browser playback failed when Torrentio streams had seeds that were regular BitTorrent TCP/UDP peers because in-browser WebTorrent can only reach WebRTC peers.  
- Provide a reliable local fallback that downloads via Node/WebTorrent and exposes an HTTP ranged video endpoint the browser can play.  

### Description
- Add a small Node/WebTorrent HTTP bridge at `scripts/torrent-stream-server.mjs` that waits for torrent metadata, selects a playable video file, and serves it with HTTP range support and CORS.  
- Teach `TorrentPlayer` to read `VITE_TORRENT_STREAM_BASE_URL`, build a server stream URL (infoHash, filename, magnet) and, when configured, play via a normal `<video>` element using the bridge while retaining the existing in-browser WebTorrent/WebRTC fallback.  
- Add `npm` script `torrent:server` and document the local workflow in `README.md` with example env/commands to run the bridge and the dev server.  

### Testing
- Ran `npx eslint src/components/player/TorrentPlayer.tsx` which passed for the modified file.  
- Validated the server script with `node --check scripts/torrent-stream-server.mjs` which succeeded.  
- Started the bridge briefly with `npm run torrent:server` (timed run) which reported the server listening and succeeded.  
- Ran TypeScript checks with `npx tsc --noEmit --project tsconfig.app.json --noUnusedLocals false --noUnusedParameters false` which completed (project-level checks).  
- `npm run build` and `npm run lint` failed due to unrelated repo-wide TypeScript/lint errors outside the scope of these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19fce186c0832c9b7566ababcb466a)